### PR TITLE
Improve federation

### DIFF
--- a/app/jobs/helo.go
+++ b/app/jobs/helo.go
@@ -1,0 +1,65 @@
+package jobs
+//
+// GangGo Application Server
+// Copyright (C) 2017 Lukas Matt <lukas@zauberstuhl.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import (
+  federation "gopkg.in/ganggo/federation.v0"
+  run "github.com/revel/modules/jobs/app/jobs"
+  "github.com/revel/revel"
+  "gopkg.in/ganggo/ganggo.v0/app/models"
+)
+
+type Helo struct {}
+
+// Run tries to start sharing with unknown servers
+func (h Helo) Run() {
+  var pods models.Pods
+  err := pods.FindByHelo(false)
+  if err != nil {
+    revel.AppLog.Error(err.Error())
+    return
+  }
+
+  var user models.User
+  err = user.FindByUsername("hq")
+  if err != nil {
+    revel.AppLog.Error(err.Error())
+    return
+  }
+
+  for _, pod := range pods {
+    var person models.Person
+    err = person.FirstByPod(pod)
+    if err != nil {
+      revel.AppLog.Error(err.Error())
+      continue
+    }
+
+    //XXX x-social-relay
+
+    run.Now(Dispatcher{
+      User: user,
+      Message: federation.EntityContact{
+        Author: user.Person.Author,
+        Recipient: person.Author,
+        Sharing: true,
+        Following: true,
+      },
+    })
+  }
+}

--- a/app/models/persons.go
+++ b/app/models/persons.go
@@ -78,3 +78,13 @@ func (person *Person) FindByAuthor(author string) (err error) {
 
   return db.Where("author = ?", author).First(person).Error
 }
+
+func (person *Person) FirstByPod(pod Pod) error {
+  db, err := OpenDatabase()
+  if err != nil {
+    return err
+  }
+  defer db.Close()
+
+  return db.Where("pod_id = ?", pod.ID).First(person).Error
+}

--- a/app/models/pods.go
+++ b/app/models/pods.go
@@ -74,3 +74,13 @@ func (pods *Pods) FindAll() (err error) { BACKEND_ONLY()
 
   return db.Find(pods).Error
 }
+
+func (pods *Pods) FindByHelo(helo bool) error { BACKEND_ONLY()
+  db, err := OpenDatabase()
+  if err != nil {
+    return err
+  }
+  defer db.Close()
+
+  return db.Where("helo = ?", helo).Find(pods).Error
+}


### PR DESCRIPTION
Diaspora only shares public entities if at least one person is sharing with the server.
In my opinion this doesn't support federation at all, cause a new user will never know whether there is an interesting user/post/tag on a different server if no-one started sharing with the mentioned server before. This PR implements following behavior;

If the pod receives an entity from a unknown server. It will auto-follow the user with the default HQ account. This happens only once and is necessary cause Diaspora ignores the `following` parameter of the contact entity in the federation library.

- [ ] Create HQ account on first-run
- [ ] Follow an unknown server/user once
- [ ] Skip server with active relay

is blocked by #47 